### PR TITLE
Update post-release action

### DIFF
--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -28,7 +28,7 @@ echo $release_version
 echo -n "Determining next version: "
 next_version=`/increment_version.sh -p $release_version`
 echo $next_version
-echo ::set-output name=next_version::${next_version}
+echo "next_version=${next_version}" >> $GITHUB_OUTPUT
 
 echo "Configuring git"
 git config --global --add safe.directory /github/workspace


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/