### PR TITLE
Update release-notes/entrypoint.sh

### DIFF
--- a/release-notes/entrypoint.sh
+++ b/release-notes/entrypoint.sh
@@ -63,11 +63,11 @@ if [ -z "$is_version_published" ]; then
     echo "::set-output name=generated_changelog::true"
   else
     echo "Changelog not generated"
-    echo "::set-output name=generated_changelog::false"
+    echo "generated_changelog=false" >> $GITHUB_OUTPUT
   fi
 else
   echo "Tag ${next_version} already published. Skipping changelog generation"
-  echo "::set-output name=generated_changelog::false"
+  echo "generated_changelog=false" >> $GITHUB_OUTPUT
 fi
 
 exit 0


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/