### PR TITLE
Use GITHUB_OUTPUT instead of set-output command

### DIFF
--- a/release-notes/entrypoint.sh
+++ b/release-notes/entrypoint.sh
@@ -60,7 +60,7 @@ if [ -z "$is_version_published" ]; then
 
   if [ -f "CHANGELOG.md" ]; then
     echo "Changelog generated"
-    echo "::set-output name=generated_changelog::true"
+    echo "generated_changelog=true" >> $GITHUB_OUTPUT
   else
     echo "Changelog not generated"
     echo "generated_changelog=false" >> $GITHUB_OUTPUT

--- a/start-oracle-cloud-runners/action.yml
+++ b/start-oracle-cloud-runners/action.yml
@@ -66,6 +66,6 @@ runs:
           )
           INSTANCE_ID=$(echo $RESPONSE | jq -r '.data.id')
         done
-        echo "::set-output name=label::${GITHUB_RUN_ID}"
+        echo "label=${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
         sleep 60
       shell: bash


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/