### PR TITLE
feat: support specifying the tag prefix instead of hardcoding 'v'

### DIFF
--- a/deploy-github-pages/entrypoint.sh
+++ b/deploy-github-pages/entrypoint.sh
@@ -145,14 +145,17 @@ fi
 # SOURCE_FOLDER - the relative path of the source documentation folder from the root of the repo
 set_path_value_or_error "${SOURCE_FOLDER}" "" "SOURCE_FOLDER"
 
+# RELEASE_TAG_PREFIX - the tag prefix to use for a release version, defaults to 'v'
+set_value_or_error "${RELEASE_TAG_PREFIX}" "v" "RELEASE_TAG_PREFIX"
+
 # VERSION - the version number of this snapshot or release, v7.0.2 will be `7.0.2`, 7.0.x will be 7.0.x
 set_value_or_error "${VERSION}" "${GITHUB_REF_NAME}" "VERSION"
-if [[ ! "$VERSION" =~ ^v?[^.]+\.[^.]+\.[^.]+$ ]]; then
-  echo "ERROR: VERSION must be in the format 'X.X.X' or 'vX.X.X'. Got: '$VERSION'"
+if [[ ! "${VERSION}" =~ ^(${RELEASE_TAG_PREFIX})?[^.]+\.[^.]+\.[^.]+$ ]]; then
+  echo "ERROR: VERSION must be in the format 'X.X.X' or '${RELEASE_TAG_PREFIX}X.X.X'. Got: '${VERSION}'"
   exit 1
 fi
-if [[ "$VERSION" == v* ]]; then
-  VERSION="${VERSION#v}"
+if [[ $VERSION == "${RELEASE_TAG_PREFIX}"* ]]; then
+  VERSION=${VERSION:${#RELEASE_TAG_PREFIX}}
 else
   VERSION="$VERSION"
 fi

--- a/post-release/action.yml
+++ b/post-release/action.yml
@@ -19,6 +19,7 @@ runs:
         # permissions:
         #    issues: write # to close milestone (script will silently fail if not set)
         #    contents: write # to commit
+        #    pull-requests: write # to create merge PR
         #
         # This script expects the github action to have checked out the repository with fetch-depth: 0
 
@@ -66,13 +67,14 @@ runs:
         set_value_or_error "${GITHUB_WORKSPACE}" "." "GIT_SAFE_DIR"
         set_value_or_error "${GITHUB_REPOSITORY}" "" "GITHUB_REPOSITORY"
         set_value_or_error "${RELEASE_VERSION}" "${GITHUB_REF:11}" "RELEASE_VERSION"
+        set_value_or_error "${RELEASE_TAG_PREFIX}" "v" "RELEASE_TAG_PREFIX"        
 
-        if [[ ! "${RELEASE_VERSION}" =~ ^v?[^.]+\.[^.]+\.[^.]+$ ]]; then
-          echo "ERROR: RELEASE_VERSION must be in the format 'X.X.X' or 'vX.X.X'. Got: '${RELEASE_VERSION}'"
+        if [[ ! "${RELEASE_VERSION}" =~ ^(${RELEASE_TAG_PREFIX})?[^.]+\.[^.]+\.[^.]+$ ]]; then
+          echo "ERROR: RELEASE_VERSION must be in the format 'X.X.X' or '${RELEASE_TAG_PREFIX}X.X.X'. Got: '${RELEASE_VERSION}'"
           exit 1
         fi
-        if [[ "${RELEASE_VERSION}" == v* ]]; then
-          RELEASE_VERSION="${RELEASE_VERSION#v}"
+        if [[ $RELEASE_VERSION == "${RELEASE_TAG_PREFIX}"* ]]; then
+          RELEASE_VERSION=${RELEASE_VERSION:${#RELEASE_TAG_PREFIX}}
         else
           RELEASE_VERSION="${RELEASE_VERSION}"
         fi


### PR DESCRIPTION
Historically the asset pipeline has used 'rel-' instead of 'v' for release tag names.  This change allows specifying the tag prefix.