### PR TITLE
ci: audit and update GitHub Actions to ASF-approved versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,16 @@ jobs:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "☕️ Setup JDK"
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🔨 Test project"
         working-directory: 'tests'

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -27,22 +27,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "☕️ Setup JDK"
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🧐 Apache License - Release Audit Tool"
         working-directory: 'tests'
         run: ./gradlew rat
       - name: Upload RAT HTML report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rat-report
           path: build/reports/rat/index.html

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -44,7 +44,7 @@ jobs:
             echo "range=~${BRANCH%.x}.0" >> "$GITHUB_OUTPUT"
           fi
       - name: "📝 Update Release Draft"
-        uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        uses: release-drafter/release-drafter@e1247478eabc9f6d9cf5ec2b3547469b0e1d2767 # v7.3.1
         continue-on-error: true
         with:
           commitish: ${{ github.event.pull_request.base.ref || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,20 @@ jobs:
       - name: "📝 Establish release version"
         run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.TAG }}
           path: ${{ env.REPO_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }} # This should not be needed as ${{ github.token }} is the default, but there have been issues with it.
       - name: "☕️ Setup JDK"
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🔨 Test project"
         working-directory: '${{ env.REPO_NAME }}/tests'
@@ -57,7 +58,7 @@ jobs:
       - name: "📝 Establish release version"
         run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.TAG }}
           path: ${{ env.REPO_NAME }}
@@ -191,7 +192,7 @@ jobs:
           tag_name: ${{ env.TAG }}
           files: dev-repo/DIST_SVN_REVISION.txt
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ env.REPO_NAME }}
           ref: ${{ env.TAG }}
@@ -226,7 +227,7 @@ jobs:
       - name: "📝 Establish release version"
         run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.TAG }}
       - name: "🗳 MANUAL - Grails PMC Vote Confirmation"


### PR DESCRIPTION
## What

Audit of every GitHub Action used in this repository against the [ASF approved actions allow-list](https://github.com/apache/infrastructure-actions/blob/main/actions.yml), updating each to its current approved version and pinning every external action to a full commit SHA with a trailing comment naming the version it resolves to.

This mirrors the audit performed on grails-core in apache/grails-core#15690 and brings this repository back onto supported, allow-list-approved action versions.

## Why (setup-gradle)

The primary driver is `gradle/actions/setup-gradle`:

- The previously-used SHAs were either never on the ASF allow-list or are scheduled to **expire from it on 2026-06-20**.
- `gradle/actions` `v6.0.0` moved caching into a proprietary `enhanced` provider governed by [Gradle's commercial Terms of Use](https://gradle.com/legal/terms-of-use/). `v6.1.0` reintroduced an MIT-licensed `basic` cache provider.

Standardizing on the approved **`v6.1.0`** SHA with **`cache-provider: basic`** (3 steps) keeps us on a supported version while caching stays MIT-licensed. Each `cache-provider` line carries an inline comment documenting the distinction.

## Changes

| Action | Before | After (pinned SHA # version) |
|--------|--------|------------------------------|
| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-java` | v5.2.0 | `be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0` |
| `gradle/actions/setup-gradle` | 0723195856401067f7a2779048b490ace7a47d7c # v5.0.2 | `50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0` |
| `actions/upload-artifact` | v7.0.1 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` |
| `release-drafter/release-drafter` | 5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0 | `e1247478eabc9f6d9cf5ec2b3547469b0e1d2767 # v7.3.1` |

Plus `cache-provider: basic` added to all 3 `setup-gradle` steps.

First-party `apache/grails-github-actions/*` references and local `./.github/actions/*` composites are intentionally left unchanged.

## Verification

- Every external action is SHA-pinned with a `# version` comment; the only non-SHA refs remaining are the first-party `apache/*` `@asf` ones and local composite actions.
- All modified workflow YAML files parse cleanly.